### PR TITLE
remove reference to media_codecs_ffmpeg.xml

### DIFF
--- a/msm8974.mk
+++ b/msm8974.mk
@@ -105,7 +105,6 @@ PRODUCT_COPY_FILES += \
 
 # Media
 PRODUCT_COPY_FILES += \
-    frameworks/av/media/libstagefright/data/media_codecs_ffmpeg.xml:system/etc/media_codecs_ffmpeg.xml \
     frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:system/etc/media_codecs_google_audio.xml \
     frameworks/av/media/libstagefright/data/media_codecs_google_telephony.xml:system/etc/media_codecs_google_telephony.xml \
     frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:system/etc/media_codecs_google_video.xml  \


### PR DESCRIPTION
This becomes obsolete because of: https://github.com/Euphoria-OS-Legacy/android_frameworks_av/commit/a0b1229ed851c25242e08df5b3b95afc884ca5cc
Without this fix it breaks the build on Samsung msm8974 devices.
